### PR TITLE
Add branch property to RepoProcessor

### DIFF
--- a/src/repomix/core/repo_processor.py
+++ b/src/repomix/core/repo_processor.py
@@ -91,6 +91,7 @@ class RepoProcessor:
         self,
         directory: str | Path | None = None,
         repo_url: str | None = None,
+        branch: str | None = None,
         config: RepomixConfig | None = None,
         config_path: str | None = None,
         cli_options: Dict | None = None,
@@ -100,6 +101,7 @@ class RepoProcessor:
 
         self.repo_url = repo_url
         self.temp_dir = None
+        self.branch = branch
         self.directory = directory
         self.config = config
         self.config_path = config_path
@@ -124,7 +126,7 @@ class RepoProcessor:
         try:
             if self.repo_url:
                 self.temp_dir = create_temp_directory()
-                clone_repository(format_git_url(self.repo_url), self.temp_dir)
+                clone_repository(format_git_url(self.repo_url), self.temp_dir, self.branch)
                 self.directory = self.temp_dir
 
             if self.config is None:


### PR DESCRIPTION
This pull request introduces a new feature to the `RepoProcessor` class in `src/repomix/core/repo_processor.py` to support cloning a specific branch from a repository. The changes primarily involve adding a `branch` parameter to the class and ensuring it is used during repository cloning.

Enhancements to repository cloning:

* [`src/repomix/core/repo_processor.py`](diffhunk://#diff-8c85a832bfdf72415b68d2c9c0245f4c2a3682f67fa6371a3400f72e148c91b7R94): Added a `branch` parameter to the `RepoProcessor` class constructor (`__init__`) to allow specifying a branch when cloning a repository. The `branch` attribute is also initialized in the constructor. [[1]](diffhunk://#diff-8c85a832bfdf72415b68d2c9c0245f4c2a3682f67fa6371a3400f72e148c91b7R94) [[2]](diffhunk://#diff-8c85a832bfdf72415b68d2c9c0245f4c2a3682f67fa6371a3400f72e148c91b7R104)
* [`src/repomix/core/repo_processor.py`](diffhunk://#diff-8c85a832bfdf72415b68d2c9c0245f4c2a3682f67fa6371a3400f72e148c91b7L127-R129): Updated the `process` method to pass the `branch` parameter to the `clone_repository` function, enabling branch-specific cloning.